### PR TITLE
mango accounts reaload on wallet change

### DIFF
--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -18,7 +18,7 @@ const TopBar = () => {
   const { t } = useTranslation('common')
   const mangoAccount = mangoStore((s) => s.mangoAccount.current)
   const connected = mangoStore((s) => s.connected)
-  const [isOnboarded] = useLocalStorageState(IS_ONBOARDED_KEY)
+  const [isOnBoarded] = useLocalStorageState(IS_ONBOARDED_KEY)
   const [showUserSetupModal, setShowUserSetupModal] = useState(false)
   const [showCreateAccountModal, setShowCreateAccountModal] = useState(false)
   const [showMangoAccountsModal, setShowMangoAccountsModal] = useState(false)
@@ -89,7 +89,7 @@ const TopBar = () => {
             </button>
             <ConnectedMenu />
           </div>
-        ) : isOnboarded ? (
+        ) : isOnBoarded ? (
           <ConnectWalletButton />
         ) : (
           <button

--- a/components/account/AccountPage.tsx
+++ b/components/account/AccountPage.tsx
@@ -73,7 +73,7 @@ const AccountPage = () => {
   const [showExpandChart, setShowExpandChart] = useState<boolean>(false)
   const { theme } = useTheme()
   const tourSettings = mangoStore((s) => s.settings.tours)
-  const [isOnboarded] = useLocalStorageState(IS_ONBOARDED_KEY)
+  const [isOnBoarded] = useLocalStorageState(IS_ONBOARDED_KEY)
 
   const leverage = useMemo(() => {
     if (!group || !mangoAccount) return 0
@@ -471,7 +471,7 @@ const AccountPage = () => {
           onClose={() => setShowWithdrawModal(false)}
         />
       ) : null}
-      {!tourSettings?.account_tour_seen && isOnboarded && connected ? (
+      {!tourSettings?.account_tour_seen && isOnBoarded && connected ? (
         <AccountOnboardingTour />
       ) : null}
     </>

--- a/components/modals/UserSetupModal.tsx
+++ b/components/modals/UserSetupModal.tsx
@@ -52,7 +52,7 @@ const UserSetupModal = ({ isOpen, onClose }: ModalProps) => {
   const [submitDeposit, setSubmitDeposit] = useState(false)
   const [sizePercentage, setSizePercentage] = useState('')
   const [showEditProfilePic, setShowEditProfilePic] = useState(false)
-  const [, setIsOnboarded] = useLocalStorageState(IS_ONBOARDED_KEY)
+  const [, setIsOnBoarded] = useLocalStorageState(IS_ONBOARDED_KEY)
   const walletTokens = mangoStore((s) => s.wallet.tokens)
 
   const handleNextStep = () => {
@@ -64,7 +64,7 @@ const UserSetupModal = ({ isOpen, onClose }: ModalProps) => {
       try {
         await handleWalletConnect(wallet)
         setShowSetupStep(2)
-        setIsOnboarded(true)
+        setIsOnBoarded(true)
       } catch (e) {
         notify({
           title: 'Setup failed. Refresh and try again.',

--- a/components/wallet/ConnectWalletButton.tsx
+++ b/components/wallet/ConnectWalletButton.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'next-i18next'
 import uniqBy from 'lodash/uniqBy'
 import WalletSelect from './WalletSelect'
 import mangoStore from '@store/mangoStore'
-import { Wallet as AnchorWallet } from '@project-serum/anchor'
 import { notify } from '../../utils/notifications'
 import Loading from '../shared/Loading'
 
@@ -13,13 +12,10 @@ export const handleWalletConnect = async (wallet: Wallet) => {
   if (!wallet) {
     return
   }
-  const actions = mangoStore.getState().actions
   const set = mangoStore.getState().set
 
   try {
     await wallet?.adapter?.connect()
-    await actions.connectMangoClientWithWallet(wallet)
-    await onConnectFetchAccountData(wallet)
     set((state) => {
       state.connected = true
     })
@@ -39,14 +35,6 @@ export const handleWalletConnect = async (wallet: Wallet) => {
       })
     }
   }
-}
-
-const onConnectFetchAccountData = async (wallet: Wallet) => {
-  if (!wallet) return
-  const actions = mangoStore.getState().actions
-  await actions.fetchMangoAccounts(wallet.adapter as unknown as AnchorWallet)
-  actions.fetchTourSettings(wallet.adapter.publicKey?.toString() as string)
-  actions.fetchWalletTokens(wallet.adapter as unknown as AnchorWallet)
 }
 
 export const ConnectWalletButton: React.FC = () => {

--- a/store/mangoStore.ts
+++ b/store/mangoStore.ts
@@ -599,12 +599,24 @@ const mangoStore = create<MangoStore>()(
               group,
               wallet.publicKey
             )
-            if (!mangoAccounts?.length) return
+            const selectedAccountIsNotInAccountsList = mangoAccounts.find(
+              (x) =>
+                x.publicKey.toBase58() ===
+                selectedMangoAccount?.publicKey.toBase58()
+            )
+            if (!mangoAccounts?.length) {
+              set((state) => {
+                state.mangoAccounts = []
+                state.mangoAccount.current = undefined
+                state.mangoAccount.lastUpdatedAt = new Date().toISOString()
+              })
+              return
+            }
 
             mangoAccounts.forEach((ma) => ma.reloadAccountData(client))
 
             let newSelectedMangoAccount = selectedMangoAccount
-            if (!selectedMangoAccount) {
+            if (!selectedMangoAccount || !selectedAccountIsNotInAccountsList) {
               const lastAccount = localStorage.getItem(LAST_ACCOUNT_KEY)
               newSelectedMangoAccount = mangoAccounts[0]
 


### PR DESCRIPTION
fix for - Brand new wallet can’t create an account if the isOnboarded variable is true in localStorage and if you change wallet (Phantom) when connected to the ui the connected wallet updates but the accounts are from the previous wallet so transactions fail

So i think proper route for that is if someone has isOnBoarded in localstorage then we show for him create account in the top bar but there is no "tutoraial"

it will reload mango accounts on wallet change instand of reload on connecting the wallet

i want to confirm if the flow is right now.