### PR TITLE
format swap token symbols

### DIFF
--- a/components/swap/SwapFormTokenList.tsx
+++ b/components/swap/SwapFormTokenList.tsx
@@ -11,6 +11,7 @@ import useJupiterMints from 'hooks/useJupiterMints'
 import useMangoGroup from 'hooks/useMangoGroup'
 import { PublicKey } from '@solana/web3.js'
 import FormatNumericValue from '@components/shared/FormatNumericValue'
+import { formatTokenSymbol } from 'utils/tokens'
 
 // const generateSearchTerm = (item: Token, searchValue: string) => {
 //   const normalizedSearchValue = searchValue.toLowerCase()
@@ -72,7 +73,7 @@ const TokenItem = ({
           </picture>
           <div className="ml-2.5">
             <p className="text-left text-th-fgd-2">
-              {symbol || 'unknown'}
+              {bank?.name ? formatTokenSymbol(bank.name) : symbol || 'unknown'}
               {bank?.reduceOnly ? (
                 <span className="ml-1.5 text-xxs text-th-warning">
                   {t('reduce-only')}

--- a/components/swap/TokenSelect.tsx
+++ b/components/swap/TokenSelect.tsx
@@ -7,6 +7,7 @@ import useMangoGroup from 'hooks/useMangoGroup'
 import useJupiterMints from 'hooks/useJupiterMints'
 import { Bank } from '@blockworks-foundation/mango-v4'
 import { Dispatch, SetStateAction } from 'react'
+import { formatTokenSymbol } from 'utils/tokens'
 
 type TokenSelectProps = {
   bank: Bank | undefined
@@ -41,7 +42,9 @@ const TokenSelect = ({ bank, showTokenList, type }: TokenSelectProps) => {
         )}
       </div>
       <div className="flex w-full items-center justify-between">
-        <div className="text-xl font-bold text-th-fgd-1">{bank?.name}</div>
+        <div className="text-xl font-bold text-th-fgd-1">
+          {formatTokenSymbol(bank!.name)}
+        </div>
         <ChevronDownIcon className="h-6 w-6" />
       </div>
     </div>

--- a/utils/tokens.ts
+++ b/utils/tokens.ts
@@ -102,5 +102,10 @@ export const fetchNftsFromHolaplexIndexer = async (owner: PublicKey) => {
   return body.data
 }
 
-export const formatTokenSymbol = (symbol: string) =>
-  symbol === 'MSOL' ? 'mSOL' : symbol
+export const formatTokenSymbol = (symbol: string) => {
+  if (symbol.toLowerCase().includes('portal')) {
+    const truncSymbol = symbol.split(' ')[0]
+    return truncSymbol === 'WBTC' ? 'wBTC' : truncSymbol
+  }
+  return symbol === 'MSOL' ? 'mSOL' : symbol
+}


### PR DESCRIPTION
Having (Portal) as part of the symbols causes issues on the swap page. Think it would be better to not have this part of the name but as a standalone property.

Current:
<img width="440" alt="Screen Shot 2023-04-17 at 11 00 25 am" src="https://user-images.githubusercontent.com/30796577/232355605-3f4ab3c0-19c1-4925-bdaf-9a2165243362.png">

New:
<img width="432" alt="Screen Shot 2023-04-17 at 11 00 58 am" src="https://user-images.githubusercontent.com/30796577/232355627-dbb94e7d-ed5e-4ec9-bbed-cfa364a497ab.png">

Still shows how it's bridged in the long-form name:
<img width="432" alt="Screen Shot 2023-04-17 at 11 01 11 am" src="https://user-images.githubusercontent.com/30796577/232355693-a9756bbc-6334-400e-bb1f-e849ae9f1f48.png">

