### PR TITLE
fix swap review transition

### DIFF
--- a/components/swap/SwapForm.tsx
+++ b/components/swap/SwapForm.tsx
@@ -281,14 +281,14 @@ const SwapForm = () => {
     >
       <div>
         <Transition
-          className="absolute top-0 left-0 z-10 h-full w-full bg-th-bkg-1 pb-0"
+          className="absolute top-0 right-0 z-10 h-full w-full bg-th-bkg-1 pb-0"
           show={showConfirm}
           enter="transition ease-in duration-300"
-          enterFrom="translate-x-full"
+          enterFrom="-translate-x-full"
           enterTo="translate-x-0"
           leave="transition ease-out duration-300"
           leaveFrom="translate-x-0"
-          leaveTo="translate-x-full"
+          leaveTo="-translate-x-full"
         >
           <SwapReviewRouteInfo
             onClose={() => setShowConfirm(false)}


### PR DESCRIPTION
The current transition between the swap form and review isn't working nicely because it pushes the width (you can see the form move left as review panel transitions above). This pr flips the direction of the transition which works nicely. Tried to fix it going in the current direction. Can look into it more if you oppose this solution.