### PR TITLE
add token fees collected chart

### DIFF
--- a/components/stats/MangoPerpStatsCharts.tsx
+++ b/components/stats/MangoPerpStatsCharts.tsx
@@ -75,25 +75,8 @@ const MangoPerpStatsCharts = () => {
 
   return (
     <>
-      {totalOpenInterestValues.length ? (
-        <div className="col-span-2 border-b border-th-bkg-3 py-4 px-6 md:col-span-1">
-          <DetailedAreaChart
-            data={totalOpenInterestValues}
-            daysToShow={oiDaysToShow}
-            setDaysToShow={setOiDaysToShow}
-            heightClass="h-64"
-            loading={loadingPerpStats}
-            loaderHeightClass="h-[350px]"
-            prefix="$"
-            tickFormat={(x) => `$${Math.floor(x)}`}
-            title={t('trade:open-interest')}
-            xKey="date"
-            yKey={'openInterest'}
-          />
-        </div>
-      ) : null}
       {totalFeeValues.length ? (
-        <div className="col-span-2 border-b border-th-bkg-3 py-4 px-6 md:col-span-1 md:border-l md:pl-6">
+        <div className="col-span-2 border-b border-th-bkg-3 py-4 px-6 md:col-span-1 md:pl-6">
           <DetailedAreaChart
             data={totalFeeValues}
             daysToShow={feesDaysToShow}
@@ -106,6 +89,23 @@ const MangoPerpStatsCharts = () => {
             title="Perp Fees"
             xKey="date"
             yKey={'feeValue'}
+          />
+        </div>
+      ) : null}
+      {totalOpenInterestValues.length ? (
+        <div className="col-span-2 border-b border-th-bkg-3 py-4 px-6 md:col-span-1 md:border-r">
+          <DetailedAreaChart
+            data={totalOpenInterestValues}
+            daysToShow={oiDaysToShow}
+            setDaysToShow={setOiDaysToShow}
+            heightClass="h-64"
+            loading={loadingPerpStats}
+            loaderHeightClass="h-[350px]"
+            prefix="$"
+            tickFormat={(x) => `$${Math.floor(x)}`}
+            title={t('trade:open-interest')}
+            xKey="date"
+            yKey={'openInterest'}
           />
         </div>
       ) : null}

--- a/components/stats/MangoStats.tsx
+++ b/components/stats/MangoStats.tsx
@@ -1,10 +1,10 @@
 import MangoPerpStatsCharts from './MangoPerpStatsCharts'
-import TotalDepositBorrowCharts from './TotalDepositBorrowCharts'
+import TokenStatsCharts from './TokenStatsCharts'
 
 const MangoStats = () => {
   return (
     <div className="grid grid-cols-2">
-      <TotalDepositBorrowCharts />
+      <TokenStatsCharts />
       <MangoPerpStatsCharts />
     </div>
   )

--- a/public/locales/en/token.json
+++ b/public/locales/en/token.json
@@ -17,6 +17,7 @@
     "no-borrowers": "No Borrowers...",
     "no-depositors": "No Depositors...",
     "token-details": "Token Details",
+    "token-fees-collected": "Token Fees Collected (M2M)",
     "token-not-found": "Token Not Found",
     "token-not-found-desc": "'{{token}}' is either not listed or we're having issues loading the data.",
     "top-borrowers": "Top {{symbol}} Borrowers",

--- a/public/locales/es/token.json
+++ b/public/locales/es/token.json
@@ -17,6 +17,7 @@
     "no-borrowers": "No Borrowers...",
     "no-depositors": "No Depositors...",
     "token-details": "Token Details",
+    "token-fees-collected": "Token Fees Collected (M2M)",
     "token-not-found": "Token Not Found",
     "token-not-found-desc": "'{{token}}' is either not listed or we're having issues loading the data.",
     "top-borrowers": "Top {{symbol}} Borrowers",

--- a/public/locales/ru/token.json
+++ b/public/locales/ru/token.json
@@ -17,6 +17,7 @@
     "no-borrowers": "No Borrowers...",
     "no-depositors": "No Depositors...",
     "token-details": "Token Details",
+    "token-fees-collected": "Token Fees Collected (M2M)",
     "token-not-found": "Token Not Found",
     "token-not-found-desc": "'{{token}}' is either not listed or we're having issues loading the data.",
     "top-borrowers": "Top {{symbol}} Borrowers",

--- a/public/locales/zh/token.json
+++ b/public/locales/zh/token.json
@@ -17,6 +17,7 @@
     "no-borrowers": "No Borrowers...",
     "no-depositors": "No Depositors...",
     "token-details": "Token Details",
+    "token-fees-collected": "Token Fees Collected (M2M)",
     "token-not-found": "Token Not Found",
     "token-not-found-desc": "'{{token}}' is either not listed or we're having issues loading the data.",
     "top-borrowers": "Top {{symbol}} Borrowers",

--- a/public/locales/zh_tw/token.json
+++ b/public/locales/zh_tw/token.json
@@ -17,6 +17,7 @@
     "no-borrowers": "無借貸者...",
     "no-depositors": "無存款者...",
     "token-details": "幣種細節",
+    "token-fees-collected": "Token Fees Collected (M2M)",
     "token-not-found": "查不到幣種",
     "token-not-found-desc": "'{{token}}'未列入或我們在加載數據時出錯。",
     "top-borrowers": "頂級{{symbol}}借貸者",


### PR DESCRIPTION
Adds token fees collected chart to Mango stats. The values are marked-to-market so assumes the DAO holds these fees in their native form perpetually