### PR TITLE
align tooltip styles

### DIFF
--- a/components/stats/PerpMarketsOverviewTable.tsx
+++ b/components/stats/PerpMarketsOverviewTable.tsx
@@ -20,7 +20,6 @@ import Tooltip from '@components/shared/Tooltip'
 import { PerpStatsItem } from 'types'
 import useMangoGroup from 'hooks/useMangoGroup'
 import { NextRouter, useRouter } from 'next/router'
-import { InformationCircleIcon } from '@heroicons/react/24/outline'
 import SimpleAreaChart from '@components/shared/SimpleAreaChart'
 
 export const getOneDayPerpStats = (
@@ -189,13 +188,15 @@ const PerpMarketsOverviewTable = () => {
                   </Td>
                   <Td>
                     <div className="flex items-center justify-end">
-                      <p className="">{fundingRate}</p>
                       <Tooltip
                         content={
                           <>
                             {fundingRateApr ? (
                               <div className="">
-                                The 1hr rate as an APR is {fundingRateApr}.
+                                The 1hr rate as an APR is{' '}
+                                <span className="font-mono text-th-fgd-2">
+                                  {fundingRateApr}
+                                </span>
                               </div>
                             ) : null}
                             <div className="mt-2">
@@ -210,7 +211,7 @@ const PerpMarketsOverviewTable = () => {
                           </>
                         }
                       >
-                        <InformationCircleIcon className="ml-2 h-4 w-4" />
+                        <p className="tooltip-underline">{fundingRate}</p>
                       </Tooltip>
                     </div>
                   </Td>

--- a/components/trade/AdvancedMarketHeader.tsx
+++ b/components/trade/AdvancedMarketHeader.tsx
@@ -101,7 +101,9 @@ const AdvancedMarketHeader = ({
               <OraclePrice setChangePrice={setChangePrice} />
             </>
             <div className="ml-6 flex-col whitespace-nowrap">
-              <div className="text-xs text-th-fgd-4">{t('rolling-change')}</div>
+              <div className="mb-0.5 text-xs text-th-fgd-4">
+                {t('rolling-change')}
+              </div>
               {!loadingPrices && !loadingPerpStats ? (
                 <Change change={change} size="small" suffix="%" />
               ) : (
@@ -114,7 +116,7 @@ const AdvancedMarketHeader = ({
               <>
                 <PerpFundingRate />
                 <div className="ml-6 flex-col whitespace-nowrap text-xs">
-                  <div className="text-th-fgd-4">
+                  <div className="mb-0.5 text-th-fgd-4 ">
                     {t('trade:open-interest')}
                   </div>
                   <span className="font-mono">

--- a/components/trade/OraclePrice.tsx
+++ b/components/trade/OraclePrice.tsx
@@ -1,7 +1,4 @@
-import {
-  ExclamationTriangleIcon,
-  InformationCircleIcon,
-} from '@heroicons/react/24/outline'
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
 import useSelectedMarket from 'hooks/useSelectedMarket'
 import Tooltip from '@components/shared/Tooltip'
 import { useTranslation } from 'next-i18next'
@@ -167,14 +164,12 @@ const OraclePrice = ({
           }
         >
           <div className="flex items-center">
-            <div className="text-xs text-th-fgd-4">
+            <div className="tooltip-underline mb-0.5 text-xs text-th-fgd-4">
               {t('trade:oracle-price')}
             </div>
             {isStale ? (
               <ExclamationTriangleIcon className="ml-1 h-4 w-4 text-th-warning" />
-            ) : (
-              <InformationCircleIcon className="ml-1 h-4 w-4 text-th-fgd-4" />
-            )}
+            ) : null}
           </div>
         </Tooltip>
         <div className="font-mono text-xs text-th-fgd-2">

--- a/components/trade/PerpFundingRate.tsx
+++ b/components/trade/PerpFundingRate.tsx
@@ -1,5 +1,4 @@
 import { BookSide, PerpMarket } from '@blockworks-foundation/mango-v4'
-import { InformationCircleIcon } from '@heroicons/react/24/outline'
 import { useQuery } from '@tanstack/react-query'
 import useMangoGroup from 'hooks/useMangoGroup'
 import useSelectedMarket from 'hooks/useSelectedMarket'
@@ -164,10 +163,10 @@ const PerpFundingRate = () => {
           }
         >
           <div className="flex items-center">
-            <div className="text-xs text-th-fgd-4">
+            <div className="tooltip-underline mb-0.5 text-xs text-th-fgd-4">
               {t('trade:funding-rate')}
             </div>
-            <InformationCircleIcon className="ml-1 h-4 w-4 text-th-fgd-4" />
+            {/* <InformationCircleIcon className="ml-1 h-4 w-4 text-th-fgd-4" /> */}
           </div>
         </Tooltip>
         <p className="font-mono text-xs text-th-fgd-2">


### PR DESCRIPTION
For UI consistency we should have one style for tooltips

Changes:

<img width="675" alt="Screen Shot 2023-05-12 at 2 05 57 pm" src="https://github.com/blockworks-foundation/mango-v4-ui/assets/30796577/00724bce-5b25-4739-ae01-25db4ded7643">

<img width="180" alt="Screen Shot 2023-05-12 at 2 05 07 pm" src="https://github.com/blockworks-foundation/mango-v4-ui/assets/30796577/e3cfdbff-a479-4f5b-96b1-6ae7426ef9f2">
