### PR TITLE
Use token for birdeye prices instead of market

### DIFF
--- a/components/stats/SpotMarketsTable.tsx
+++ b/components/stats/SpotMarketsTable.tsx
@@ -84,7 +84,7 @@ const SpotMarketsTable = () => {
                 }
 
                 const birdeyeData = birdeyePrices.find(
-                  (m) => m.mint === mkt.serumMarketExternal.toString()
+                  (m) => m.mint === baseBank?.mint.toString()
                 )
 
                 const change =
@@ -217,9 +217,7 @@ const MobileSpotMarketItem = ({
 
   const birdeyeData = useMemo(() => {
     if (!loadingPrices) {
-      return birdeyePrices.find(
-        (m) => m.mint === market.serumMarketExternal.toString()
-      )
+      return birdeyePrices.find((m) => m.mint === baseBank?.mint.toString())
     }
     return null
   }, [loadingPrices])

--- a/components/trade/AdvancedMarketHeader.tsx
+++ b/components/trade/AdvancedMarketHeader.tsx
@@ -87,9 +87,11 @@ const AdvancedMarketHeader = ({
       selectedMarket instanceof PerpMarket
     )
       return
-    return birdeyePrices.find(
-      (m) => m.mint === selectedMarket.serumMarketExternal.toString()
+
+    const baseBank = group?.getFirstBankByTokenIndex(
+      selectedMarket.baseTokenIndex
     )
+    return birdeyePrices.find((m) => m.mint === baseBank?.mint.toString())
   }, [birdeyePrices, selectedMarket])
 
   const oneDayPerpStats = useMemo(() => {

--- a/components/trade/MarketSelectDropdown.tsx
+++ b/components/trade/MarketSelectDropdown.tsx
@@ -149,15 +149,14 @@ const MarketSelectDropdown = () => {
                   .map((x) => x)
                   .sort((a, b) => a.name.localeCompare(b.name))
                   .map((m) => {
-                    const birdeyeData = birdeyePrices?.length
-                      ? birdeyePrices.find(
-                          (market) =>
-                            market.mint === m.serumMarketExternal.toString()
-                        )
-                      : null
                     const baseBank = group?.getFirstBankByTokenIndex(
                       m.baseTokenIndex
                     )
+                    const birdeyeData = birdeyePrices?.length
+                      ? birdeyePrices.find(
+                          (prices) => prices.mint === baseBank?.mint.toString()
+                        )
+                      : null
                     const quoteBank = group?.getFirstBankByTokenIndex(
                       m.quoteTokenIndex
                     )


### PR DESCRIPTION
For new/low volume Openbook markets Birdeye seems to always report a price of 1 and is slow to update when fills occur, the effect of which was an incorrect 24hr change value for LDO/USDC (https://birdeye.so/token/HZRCwxP2Vq9PCpPXooayhJ2bxTpo5xfpQrwB1svh332p/BqApFW7DwXThCDZAbK13nbHksEsv6YJMCdj58sJmRLdy?chain=solana&tab=recentTrades). By no means a major issue but made the UI looks a bit strange.

This PR queries for the token price instead. This carries some issues as well, if the spot market price diverged from the AMM price sources that feed into the Birdeye token price data, then it won't match up as expected when the user views the chart.

Happy to discuss further, maybe there is a better solution.