### PR TITLE
Update funding sign to match smart contract

### DIFF
--- a/components/account/AccountPage.tsx
+++ b/components/account/AccountPage.tsx
@@ -59,7 +59,11 @@ const fetchFundingTotals = async (mangoAccountPk: string) => {
 
       const stats: TotalAccountFundingItem[] = entries
         .map(([key, value]) => {
-          return { ...value, market: key }
+          return {
+            long_funding: value.long_funding * -1,
+            short_funding: value.short_funding * -1,
+            market: key,
+          }
         })
         .filter((x) => x)
 

--- a/components/account/FundingDetails.tsx
+++ b/components/account/FundingDetails.tsx
@@ -45,7 +45,11 @@ const fetchHourlyFunding = async (mangoAccountPk: string) => {
       const stats: HourlyFundingStatsData[] = entries.map(([key, value]) => {
         const marketEntries = Object.entries(value)
         const marketFunding = marketEntries.map(([key, value]) => {
-          return { ...value, time: key }
+          return {
+            long_funding: value.long_funding * -1,
+            short_funding: value.short_funding * -1,
+            time: key,
+          }
         })
         return { marketFunding, market: key }
       })


### PR DESCRIPTION
Previously, the offchain service responsible for tracking funding was multiplying by -1 for readability. In order to stay true to the smart contract, we are planning to revert 

As an example, the offchain service currently displays a user paying $1 in funding for a long position as -1e6. We can see the opposite in the contract:
https://github.com/blockworks-foundation/mango-v4/blob/eeef6711ab8f20bc8fc898686fa9a0f15ffd0200/programs/mango-v4/src/state/mango_account_components.rs#L212-L222.

In order to ensure that the UI stays easily readable to users, we should multiply funding by -1 here instead of the offchain service.