### PR TITLE
add buffer when withdrawing with open positions

### DIFF
--- a/hooks/useBanksWithBalances.ts
+++ b/hooks/useBanksWithBalances.ts
@@ -50,9 +50,12 @@ export default function useBanksWithBalances(
         const maxBorrow = mangoAccount
           ? getMaxWithdrawForBank(group, bank, mangoAccount, true).toNumber()
           : 0
-        const maxWithdraw = mangoAccount
+        let maxWithdraw = mangoAccount
           ? getMaxWithdrawForBank(group, bank, mangoAccount).toNumber()
           : 0
+        if (maxWithdraw < balance) {
+          maxWithdraw = maxWithdraw * 0.998
+        }
         const borrowedAmount = mangoAccount
           ? floorToDecimal(
               mangoAccount.getTokenBorrowsUi(bank),


### PR DESCRIPTION
Currently, withdrawals can fail if prices move during the withdrawal process. This adds a small buffer when withdrawing the max amount with open positions.