### PR TITLE
Fix token page links for mixed case symbols

### DIFF
--- a/components/stats/TokenDetailsTable.tsx
+++ b/components/stats/TokenDetailsTable.tsx
@@ -116,10 +116,7 @@ const TokenDetailsTable = () => {
                     className="default-transition md:hover:cursor-pointer md:hover:bg-th-bkg-2"
                     key={bank.name}
                     onClick={() =>
-                      goToTokenPage(
-                        bank.name.split(' ')[0].toUpperCase(),
-                        router
-                      )
+                      goToTokenPage(bank.name.split(' ')[0], router)
                     }
                   >
                     <Td>
@@ -357,10 +354,7 @@ const TokenDetailsTable = () => {
                             <LinkButton
                               className="flex items-center"
                               onClick={() =>
-                                goToTokenPage(
-                                  bank.name.split(' ')[0].toUpperCase(),
-                                  router
-                                )
+                                goToTokenPage(bank.name.split(' ')[0], router)
                               }
                             >
                               {t('token:token-stats', { token: bank.name })}

--- a/components/stats/TokenOverviewTable.tsx
+++ b/components/stats/TokenOverviewTable.tsx
@@ -109,10 +109,7 @@ const TokenOverviewTable = () => {
                     className="default-transition md:hover:cursor-pointer md:hover:bg-th-bkg-2"
                     key={bank.name}
                     onClick={() =>
-                      goToTokenPage(
-                        bank.name.split(' ')[0].toUpperCase(),
-                        router
-                      )
+                      goToTokenPage(bank.name.split(' ')[0], router)
                     }
                   >
                     <Td>
@@ -359,10 +356,7 @@ const TokenOverviewTable = () => {
                             <LinkButton
                               className="flex items-center"
                               onClick={() =>
-                                goToTokenPage(
-                                  bank.name.split(' ')[0].toUpperCase(),
-                                  router
-                                )
+                                goToTokenPage(bank.name.split(' ')[0], router)
                               }
                             >
                               {t('token:token-stats', { token: bank.name })}

--- a/components/token/TokenPage.tsx
+++ b/components/token/TokenPage.tsx
@@ -76,7 +76,7 @@ const TokenPage = () => {
 
   const bankName = useMemo(() => {
     if (!token) return
-    return token === 'WBTC'
+    return token === 'wBTC'
       ? 'wBTC (Portal)'
       : token === 'ETH'
       ? 'ETH (Portal)'


### PR DESCRIPTION
Clicking through to the token detail page from the stats table give a 'Token not found' error due to the capitalisation of the query string var. This change respects the original case of the symbol so the bank name can be matched.