### PR TITLE
show avg entry price in perp trade summary

### DIFF
--- a/components/trade/TradeSummary.tsx
+++ b/components/trade/TradeSummary.tsx
@@ -17,10 +17,11 @@ import Slippage from './Slippage'
 import {
   floorToDecimal,
   formatNumericValue,
-  // getDecimalCount,
+  getDecimalCount,
 } from 'utils/numbers'
 import { formatTokenSymbol } from 'utils/tokens'
-// import useOpenPerpPositions from 'hooks/useOpenPerpPositions'
+import useOpenPerpPositions from 'hooks/useOpenPerpPositions'
+import { calculateEstPriceForBaseSize } from 'utils/tradeForm'
 
 const TradeSummary = ({
   mangoAccount,
@@ -33,28 +34,63 @@ const TradeSummary = ({
   const { group } = useMangoGroup()
   const tradeForm = mangoStore((s) => s.tradeForm)
   const { selectedMarket, quoteBank } = useSelectedMarket()
-  // const openPerpPositions = useOpenPerpPositions()
+  const openPerpPositions = useOpenPerpPositions()
 
-  // this isn't correct yet
+  // calc new avg price if an open position exists
+  const avgEntryPrice = useMemo(() => {
+    if (
+      !openPerpPositions.length ||
+      !selectedMarket ||
+      selectedMarket instanceof Serum3Market
+    )
+      return
 
-  // const avgEntryPrice = useMemo(() => {
-  //   if (
-  //     !openPerpPositions.length ||
-  //     !selectedMarket ||
-  //     selectedMarket instanceof Serum3Market
-  //   )
-  //     return
-  //   const openPosition = openPerpPositions.find(
-  //     (pos) => pos.marketIndex === selectedMarket.perpMarketIndex
-  //   )
-  //   if (openPosition && tradeForm.price) {
-  //     const currentAvgPrice =
-  //       openPosition.getAverageEntryPriceUi(selectedMarket)
-  //     const newAvgPrice = (currentAvgPrice + Number(tradeForm.price)) / 2
-  //     return newAvgPrice
-  //   }
-  //   return
-  // }, [openPerpPositions, selectedMarket, tradeForm])
+    const openPosition = openPerpPositions.find(
+      (pos) => pos.marketIndex === selectedMarket.perpMarketIndex
+    )
+
+    const { baseSize, price, reduceOnly, side, tradeType } = tradeForm
+
+    if (!openPosition || !price) return
+
+    let orderPrice = parseFloat(price)
+    if (tradeType === 'Market') {
+      const orderbook = mangoStore((s) => s.selectedMarket.orderbook)
+      orderPrice = calculateEstPriceForBaseSize(
+        orderbook,
+        parseFloat(tradeForm.baseSize),
+        tradeForm.side
+      )
+    }
+    const currentSize = openPosition.getBasePositionUi(selectedMarket)
+    const tradeSize =
+      side === 'buy' ? parseFloat(baseSize) : parseFloat(baseSize) * -1
+    const newTotalSize = currentSize + tradeSize
+    const currentAvgPrice = openPosition.getAverageEntryPriceUi(selectedMarket)
+
+    // don't calc when closing position
+    if (newTotalSize === 0) {
+      return
+    }
+
+    // don't calc when reducing position
+    if (
+      (currentSize < 0 !== tradeSize < 0 &&
+        newTotalSize < 0 === currentSize < 0) ||
+      reduceOnly
+    ) {
+      return
+    }
+
+    // if trade side changes with new trade return new trade price
+    if (currentSize < 0 !== newTotalSize < 0) {
+      return price
+    }
+
+    const newTotalCost = currentAvgPrice * currentSize + orderPrice * tradeSize
+    const newAvgEntryPrice = newTotalCost / newTotalSize
+    return newAvgEntryPrice
+  }, [openPerpPositions, selectedMarket, tradeForm])
 
   const maintProjectedHealth = useMemo(() => {
     if (!mangoAccount || !group) return 100
@@ -240,11 +276,11 @@ const TradeSummary = ({
         </p>
       </div> */}
       <Slippage />
-      {/* {avgEntryPrice && selectedMarket instanceof PerpMarket ? (
+      {avgEntryPrice && selectedMarket instanceof PerpMarket ? (
         <div className="flex justify-between text-xs">
           <p>{t('trade:avg-entry-price')}</p>
           <p className="text-th-fgd-2">
-            {tradeForm.tradeType === 'Market' ? '~' : ''}
+            {tradeForm.tradeType === 'Market' ? '~' : null}
             <FormatNumericValue
               value={avgEntryPrice}
               decimals={getDecimalCount(selectedMarket.tickSize)}
@@ -252,7 +288,7 @@ const TradeSummary = ({
             />
           </p>
         </div>
-      ) : null} */}
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
– Shows a preview of the avg entry price when adding to a perp position. Requested by DL

<img width="278" alt="Screen Shot 2023-06-30 at 9 15 24 pm" src="https://github.com/blockworks-foundation/mango-v4-ui/assets/30796577/51e5f015-bbae-4e2d-9e8f-a6331e4b1118">
