### PR TITLE
Add Filled Size to the open orders table

### DIFF
--- a/components/trade/OpenOrders.tsx
+++ b/components/trade/OpenOrders.tsx
@@ -13,6 +13,7 @@ import { IconButton } from '@components/shared/Button'
 import ConnectEmptyState from '@components/shared/ConnectEmptyState'
 import FormatNumericValue from '@components/shared/FormatNumericValue'
 import Loading from '@components/shared/Loading'
+import SheenLoader from '@components/shared/SheenLoader'
 import SideBadge from '@components/shared/SideBadge'
 import { Table, Td, Th, TrBody, TrHead } from '@components/shared/TableElements'
 import Tooltip from '@components/shared/Tooltip'
@@ -30,6 +31,7 @@ import mangoStore from '@store/mangoStore'
 import useMangoAccount from 'hooks/useMangoAccount'
 import useSelectedMarket from 'hooks/useSelectedMarket'
 import useUnownedAccount from 'hooks/useUnownedAccount'
+import useFilledOrders from 'hooks/useFilledOrders'
 import { useViewport } from 'hooks/useViewport'
 import { useTranslation } from 'next-i18next'
 import Link from 'next/link'
@@ -77,6 +79,7 @@ const OpenOrders = () => {
   const { connected } = useWallet()
   const { isUnownedAccount } = useUnownedAccount()
   const { selectedMarket } = useSelectedMarket()
+  const { filledOrders, fetchingFilledOrders } = useFilledOrders()
 
   const handleCancelSerumOrder = useCallback(
     async (o: Order) => {
@@ -249,12 +252,13 @@ const OpenOrders = () => {
       <Table>
         <thead>
           <TrHead>
-            <Th className="w-[16.67%] text-left">{t('market')}</Th>
-            <Th className="w-[16.67%] text-right">{t('trade:size')}</Th>
-            <Th className="w-[16.67%] text-right">{t('price')}</Th>
-            <Th className="w-[16.67%] text-right">{t('value')}</Th>
+            <Th className="w-[14.28%] text-left">{t('market')}</Th>
+            <Th className="w-[14.28%] text-right">{t('trade:size')}</Th>
+            <Th className="w-[14.28%] text-right">{t('trade:filled-size')}</Th>
+            <Th className="w-[14.28%] text-right">{t('price')}</Th>
+            <Th className="w-[14.28%] text-right">{t('value')}</Th>
             {!isUnownedAccount ? (
-              <Th className="w-[16.67%] text-right" />
+              <Th className="w-[14.28%] text-right" />
             ) : null}
           </TrHead>
         </thead>
@@ -269,6 +273,7 @@ const OpenOrders = () => {
                 let minOrderSize: number
                 let expiryTimestamp: number | undefined
                 let value: number
+                let filledQuantity = 0
                 if (o instanceof PerpOrder) {
                   market = group.getPerpMarketByMarketIndex(o.perpMarketIndex)
                   tickSize = market.tickSize
@@ -278,6 +283,20 @@ const OpenOrders = () => {
                       ? 0
                       : o.expiryTimestamp.toNumber()
                   value = o.size * o.price
+
+                  // Find the filled perp order,
+                  // the api returns client order ids for perps, but PerpOrder[] only has orderId
+                  const mangoAccount =
+                    mangoStore.getState().mangoAccount.current
+                  const perpClientId = mangoAccount?.perpOpenOrders?.find((p) =>
+                    p.id.eq(o.orderId),
+                  )?.clientId
+                  if (perpClientId) {
+                    const filledOrder = filledOrders?.fills?.find(
+                      (f) => f.order_id == perpClientId.toString(),
+                    )
+                    filledQuantity = filledOrder ? filledOrder.quantity : 0
+                  }
                 } else {
                   market = group.getSerum3MarketByExternalMarket(
                     new PublicKey(marketPk),
@@ -291,6 +310,10 @@ const OpenOrders = () => {
                   tickSize = serumMarket.tickSize
                   minOrderSize = serumMarket.minOrderSize
                   value = o.size * o.price * quoteBank.uiPrice
+                  const filledOrder = filledOrders?.fills?.find(
+                    (f) => o.orderId.toString() === f.order_id,
+                  )
+                  filledQuantity = filledOrder ? filledOrder.quantity : 0
                 }
                 const side =
                   o instanceof PerpOrder
@@ -303,18 +326,32 @@ const OpenOrders = () => {
                     key={`${o.side}${o.size}${o.price}${o.orderId.toString()}`}
                     className="my-1 p-2"
                   >
-                    <Td className="w-[16.67%]">
+                    <Td className="w-[14.28%]">
                       <TableMarketName market={market} side={side} />
                     </Td>
                     {modifyOrderId !== o.orderId.toString() ? (
                       <>
-                        <Td className="w-[16.67%] text-right font-mono">
+                        <Td className="w-[14.28%] text-right font-mono">
                           <FormatNumericValue
                             value={o.size}
                             decimals={getDecimalCount(minOrderSize)}
                           />
                         </Td>
-                        <Td className="w-[16.67%] whitespace-nowrap text-right font-mono">
+                        <Td className="w-[14.28%] text-right font-mono">
+                          {fetchingFilledOrders ? (
+                            <div className="flex items justify-end">
+                              <SheenLoader className="flex justify-end">
+                                <div className="h-7 w-16 bg-th-bkg-2" />
+                              </SheenLoader>
+                            </div>
+                          ) : (
+                            <FormatNumericValue
+                              value={filledQuantity}
+                              decimals={getDecimalCount(minOrderSize)}
+                            />
+                          )}
+                        </Td>
+                        <Td className="w-[14.28%] whitespace-nowrap text-right font-mono">
                           <FormatNumericValue
                             value={o.price}
                             decimals={getDecimalCount(tickSize)}
@@ -323,7 +360,7 @@ const OpenOrders = () => {
                       </>
                     ) : (
                       <>
-                        <Td className="w-[16.67%]">
+                        <Td className="w-[14.28%]">
                           <input
                             className="h-8 w-full rounded-l-none rounded-r-none border-b-2 border-l-0 border-r-0 border-t-0 border-th-bkg-4 bg-transparent px-0 text-right font-mono text-sm hover:border-th-fgd-3 focus:border-th-fgd-3 focus:outline-none"
                             type="text"
@@ -333,7 +370,21 @@ const OpenOrders = () => {
                             }
                           />
                         </Td>
-                        <Td className="w-[16.67%]">
+                        <Td className="w-[14.28%] text-right font-mono">
+                          {fetchingFilledOrders ? (
+                            <div className="flex items justify-end">
+                              <SheenLoader className="flex justify-end">
+                                <div className="h-7 w-16 bg-th-bkg-2" />
+                              </SheenLoader>
+                            </div>
+                          ) : (
+                            <FormatNumericValue
+                              value={filledQuantity}
+                              decimals={getDecimalCount(minOrderSize)}
+                            />
+                          )}
+                        </Td>
+                        <Td className="w-[14.28%]">
                           <input
                             autoFocus
                             className="h-8 w-full rounded-l-none rounded-r-none border-b-2 border-l-0 border-r-0 border-t-0 border-th-bkg-4 bg-transparent px-0 text-right font-mono text-sm hover:border-th-fgd-3 focus:border-th-fgd-3 focus:outline-none"
@@ -346,7 +397,7 @@ const OpenOrders = () => {
                         </Td>
                       </>
                     )}
-                    <Td className="w-[16.67%] text-right font-mono">
+                    <Td className="w-[14.28%] text-right font-mono">
                       <FormatNumericValue value={value} isUsd />
                       {expiryTimestamp ? (
                         <div className="h-min text-xxs leading-tight text-th-fgd-4">{`Expires ${new Date(
@@ -355,7 +406,7 @@ const OpenOrders = () => {
                       ) : null}
                     </Td>
                     {!isUnownedAccount ? (
-                      <Td className="w-[16.67%]">
+                      <Td className="w-[14.28%]">
                         <div className="flex justify-end space-x-2">
                           {modifyOrderId !== o.orderId.toString() ? (
                             <>

--- a/hooks/useFilledOrders.ts
+++ b/hooks/useFilledOrders.ts
@@ -1,0 +1,53 @@
+import { PerpOrder } from '@blockworks-foundation/mango-v4'
+import mangoStore from '@store/mangoStore'
+import { useQuery } from '@tanstack/react-query'
+import { fetchFilledOrders } from 'utils/account'
+import useMangoAccount from './useMangoAccount'
+
+export default function useFilledOrders() {
+  const { mangoAccount, mangoAccountAddress } = useMangoAccount()
+  const openOrders = mangoStore((s) => s.mangoAccount.openOrders)
+  if (!mangoAccount) {
+    return {
+      filledOrders: undefined,
+      isFetching: false,
+    }
+  }
+
+  const perpIds = mangoAccount.perpOpenOrders
+    .filter((o) => o.orderMarket !== 65535)
+    .map((p) => p.clientId.toString())
+  const spotIds = Object.values(openOrders)
+    .flat()
+    .filter((o) => !(o instanceof PerpOrder))
+    .map((s) => s.orderId.toString())
+  const orderIds = spotIds.concat(perpIds)
+  if (orderIds.length === 0) {
+    return {
+      filledOrders: undefined,
+      isFetching: false,
+    }
+  }
+
+  const {
+    data: filledOrders,
+    isFetching: fetchingFilledOrders,
+    refetch,
+  } = useQuery(
+    ['filled-orders', mangoAccountAddress],
+    () => fetchFilledOrders(mangoAccountAddress, orderIds),
+    {
+      cacheTime: 1000 * 60 * 10,
+      staleTime: 30,
+      retry: 3,
+      refetchOnWindowFocus: false,
+      enabled: !!mangoAccountAddress,
+    },
+  )
+
+  return {
+    filledOrders,
+    fetchingFilledOrders,
+    refetch,
+  }
+}

--- a/public/locales/en/trade.json
+++ b/public/locales/en/trade.json
@@ -25,6 +25,7 @@
     "est-slippage": "Est. Slippage",
     "falls-to": "falls below",
     "filled": "Filled",
+    "filled-size": "Filled Size",
     "for": "for",
     "funding-limits": "Funding Limits",
     "funding-rate": "1h Avg Funding Rate",

--- a/public/locales/es/trade.json
+++ b/public/locales/es/trade.json
@@ -25,6 +25,7 @@
     "est-slippage": "Est. Slippage",
     "falls-to": "falls below",
     "filled": "Filled",
+    "filled-size": "Filled Size",
     "for": "for",
     "funding-limits": "Funding Limits",
     "funding-rate": "1h Avg Funding Rate",

--- a/public/locales/ru/trade.json
+++ b/public/locales/ru/trade.json
@@ -25,6 +25,7 @@
     "est-slippage": "Est. Slippage",
     "falls-to": "falls below",
     "filled": "Filled",
+    "filled-size": "Filled Size",
     "for": "for",
     "funding-limits": "Funding Limits",
     "funding-rate": "1h Avg Funding Rate",

--- a/public/locales/zh/trade.json
+++ b/public/locales/zh/trade.json
@@ -25,6 +25,7 @@
     "est-slippage": "预计下滑",
     "falls-to": "falls below",
     "filled": "Filled",
+    "filled-size": "Filled Size",
     "for": "for",
     "funding-limits": "资金费限制",
     "funding-rate": "1小时平均资金费",

--- a/public/locales/zh_tw/trade.json
+++ b/public/locales/zh_tw/trade.json
@@ -25,6 +25,7 @@
     "est-slippage": "預計下滑",
     "falls-to": "falls below",
     "filled": "Filled",
+    "filled-size": "Filled Size",
     "for": "for",
     "funding-limits": "資金費限制",
     "funding-rate": "1小時平均資金費",

--- a/types/index.ts
+++ b/types/index.ts
@@ -486,3 +486,13 @@ export interface ContributionDetails {
   perpMarketContributions: PerpMarketContribution[]
   spotUi: number
 }
+
+export interface FilledOrdersApiResponseType {
+  fills: FilledOrder[]
+}
+
+export interface FilledOrder {
+  order_id: string
+  order_type: 'spot' | 'perp'
+  quantity: number
+}

--- a/utils/account.ts
+++ b/utils/account.ts
@@ -2,6 +2,7 @@ import {
   AccountPerformanceData,
   AccountVolumeTotalData,
   EmptyObject,
+  FilledOrdersApiResponseType,
   FormattedHourlyAccountVolumeData,
   HourlyAccountVolumeData,
   PerformanceDataItem,
@@ -148,5 +149,22 @@ export const fetchHourlyVolume = async (mangoAccountPk: string) => {
     return formatHourlyVolumeData(hourlyVolume)
   } catch (e) {
     console.log('Failed to fetch spot volume', e)
+  }
+}
+
+export const fetchFilledOrders = async (
+  mangoAccountPk: string,
+  orderIds: string[],
+) => {
+  try {
+    const idString = orderIds.map((i) => `&id=${i}`).join('')
+    const resp = await fetch(
+      `https://api.mngo.cloud/data/v4/user-data/filled-orders?mango-account=${mangoAccountPk}` +
+        idString,
+    )
+    const response: FilledOrdersApiResponseType = await resp.json()
+    return response
+  } catch (e) {
+    console.log('Failed to fetch filled orders', e)
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1014,7 +1014,12 @@
   resolved "https://registry.yarnpkg.com/@noble/ed25519/-/ed25519-1.7.3.tgz#57e1677bf6885354b466c38e2b620c62f45a7123"
   integrity sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==
 
-"@noble/hashes@1.3.1", "@noble/hashes@^1.1.3", "@noble/hashes@^1.3.1", "@noble/hashes@~1.3.0", "@noble/hashes@~1.3.1":
+"@noble/hashes@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.0.tgz#085fd70f6d7d9d109671090ccae1d3bec62554a1"
+  integrity sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==
+
+"@noble/hashes@1.3.1", "@noble/hashes@^1.1.3", "@noble/hashes@^1.3.0", "@noble/hashes@~1.3.0", "@noble/hashes@~1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.1.tgz#8831ef002114670c603c458ab8b11328406953a9"
   integrity sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==
@@ -1954,7 +1959,7 @@
   dependencies:
     "@wallet-standard/base" "^1.0.1"
 
-"@solana/wallet-standard-features@^1.1.0":
+"@solana/wallet-standard-features@^1.0.1", "@solana/wallet-standard-features@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@solana/wallet-standard-features/-/wallet-standard-features-1.1.0.tgz#516d78626dd0802d299db49298e4ebbec3433940"
   integrity sha512-oVyygxfYkkF5INYL0GuD8GFmNO/wd45zNesIqGCFE6X66BYxmI6HmyzQJCcZTZ0BNsezlVg4t+3MCL5AhfFoGA==


### PR DESCRIPTION
I've noticed that upon switching to the orders tab, there is a slight delay in the "Filled Size" column being updated (due to the api call latency). Maybe @saml33 you have some suggestions for this visual blemish? I thought maybe a spinner could work but I'm not in love with the idea