### PR TITLE
feature/security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    commit-message:
+      prefix: 'npm'
+      prefix-development: 'npm dev'
+    labels:
+      - 'deps'
+      - 'security'
+    open-pull-requests-limit: 0 # Security updates only

--- a/.github/workflows/ci-code-review.yml
+++ b/.github/workflows/ci-code-review.yml
@@ -4,17 +4,20 @@ on:
   pull_request:
     branches: ['main']
   push:
+    branches-ignore:
+      - 'dependabot/*'
 
 jobs:
   lint:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'yarn'
@@ -29,6 +32,7 @@ jobs:
         run: yarn lint-all
 
   sast:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     name: Security Scan
     runs-on: ubuntu-latest
     permissions:
@@ -36,29 +40,25 @@ jobs:
       contents: read
       security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: ['javascript']
-
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialise CodeQL
         uses: github/codeql-action/init@v2
         with:
-          languages: ${{ matrix.language }}
+          languages: 'javascript'
 
       - name: Run CodeQL
         uses: github/codeql-action/analyze@v2
 
   sca:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     name: Dependency Scan
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Fail the job on critical vulnerabiliies with fix available
       - name: Fail on critical vulnerabilities
@@ -72,6 +72,7 @@ jobs:
           exit-code: '1'
 
   all-pass:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     name: All tests pass 🚀
     needs: ['lint', 'sast', 'sca']
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-dep-pr.yml
+++ b/.github/workflows/ci-dep-pr.yml
@@ -1,0 +1,25 @@
+name: Dependabot PR Review
+
+on:
+  pull_request:
+    branches: ['main']
+
+jobs:
+  build:
+    name: Build test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn ci
+
+      - name: Test build
+        run: yarn build

--- a/.github/workflows/ci-dep-pr.yml
+++ b/.github/workflows/ci-dep-pr.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.actor == 'dependabot[bot]' }}
     name: Build test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR contains:

- Automated PRs for dependency security updates where possible
- A workflow that runs install/build tests for PRs opened by Dependabot
- Updates to existing CI workflow to not trigger by Dependabot

The idea is:
1. Dependabot warns of a new dependency vulnerability
2. If possible, it'll open a PR to fix it
3. PR review workflow checks that the change doesn't break install/builds
4. Maintainer sees new PR and hopefully a green ticket that the change doesn't break anything
5. If tests fail, it'll require further investigation

**Note** that it won't open PRs for _all_ security updates as there might be dependency conflicts. This doesn't change the fact that we need to keep our eyes on the Security tab for manual intervention.