### PR TITLE
display dust and allow dust withdrawal

### DIFF
--- a/components/TokenList.tsx
+++ b/components/TokenList.tsx
@@ -176,7 +176,14 @@ const TokenList = () => {
       const formatted = []
       for (const b of banks) {
         const bank = b.bank
-        const balance = floorToDecimal(b.balance, bank.mintDecimals).toNumber()
+        const roundedBalance = floorToDecimal(
+          b.balance,
+          bank.mintDecimals,
+        ).toNumber()
+        let balance = roundedBalance
+        if (b.balance && !roundedBalance) {
+          balance = b.balance
+        }
         const balanceValue = balance * bank.uiPrice
         const symbol = bank.name === 'MSOL' ? 'mSOL' : bank.name
 
@@ -378,6 +385,13 @@ const TokenList = () => {
                   borrowRate,
                 } = data
 
+                const decimals = floorToDecimal(
+                  balance,
+                  bank.mintDecimals,
+                ).toNumber()
+                  ? bank.mintDecimals
+                  : undefined
+
                 return (
                   <TrBody key={symbol}>
                     <Td>
@@ -386,9 +400,11 @@ const TokenList = () => {
                     <Td className="text-right">
                       <BankAmountWithValue
                         amount={balance}
+                        decimals={decimals}
                         bank={bank}
                         stacked
                         isPrivate
+                        fixDecimals={false}
                       />
                     </Td>
                     <Td className="text-right">
@@ -521,6 +537,10 @@ const MobileTokenListItem = ({ data }: { data: TableData }) => {
     borrowRate,
   } = data
 
+  const decimals = floorToDecimal(balance, bank.mintDecimals).toNumber()
+    ? bank.mintDecimals
+    : undefined
+
   return (
     <Disclosure>
       {({ open }) => (
@@ -533,15 +553,12 @@ const MobileTokenListItem = ({ data }: { data: TableData }) => {
               <div className="flex items-center space-x-2">
                 <div className="text-right">
                   <p className="font-mono text-sm text-th-fgd-2">
-                    <FormatNumericValue
-                      value={balance}
-                      decimals={bank.mintDecimals}
-                    />
+                    <FormatNumericValue value={balance} decimals={decimals} />
                   </p>
                   <span className="font-mono text-xs text-th-fgd-3">
                     <FormatNumericValue
                       value={mangoAccount ? balance * bank.uiPrice : 0}
-                      decimals={2}
+                      decimals={decimals ? 2 : undefined}
                       isUsd
                       isPrivate
                     />

--- a/components/WithdrawForm.tsx
+++ b/components/WithdrawForm.tsx
@@ -63,12 +63,13 @@ function WithdrawForm({ onSuccess, token }: WithdrawFormProps) {
     return group?.banksMapByName.get(selectedToken)?.[0]
   }, [selectedToken])
 
-  const [adjustedTokenMax, tokenMax] = useMemo(() => {
-    if (!bank || !mangoAccount || !group)
-      return [new Decimal(0), new Decimal(0)]
+  const [tokenMax, decimals] = useMemo(() => {
+    if (!bank || !mangoAccount || !group) return [new Decimal(0), undefined]
     const tokenMax = getMaxWithdrawForBank(group, bank, mangoAccount).toNumber()
-    const adjustedTokenMax = tokenMax
-
+    const decimals = floorToDecimal(tokenMax, bank.mintDecimals).toNumber()
+      ? bank.mintDecimals
+      : undefined
+    const roundedMax = decimals ? floorToDecimal(tokenMax, decimals) : tokenMax
     // Note: Disable for now, not sure why this was added, we can re-renable with specific conditions when
     // need is realized
     // const balance = mangoAccount.getTokenBalanceUi(bank)
@@ -76,7 +77,7 @@ function WithdrawForm({ onSuccess, token }: WithdrawFormProps) {
     //   adjustedTokenMax = tokenMax * 0.998
     // }
 
-    return [new Decimal(adjustedTokenMax), new Decimal(tokenMax)]
+    return [new Decimal(roundedMax), decimals]
   }, [mangoAccount, bank, group])
 
   const handleSizePercentage = useCallback(
@@ -85,27 +86,20 @@ function WithdrawForm({ onSuccess, token }: WithdrawFormProps) {
       setSizePercentage(percentage)
       let amount: Decimal
       if (percentage !== '100') {
-        amount = floorToDecimal(
-          new Decimal(adjustedTokenMax).mul(percentage).div(100),
-          bank.mintDecimals,
-        )
+        amount = new Decimal(tokenMax).mul(percentage).div(100)
       } else {
-        amount = floorToDecimal(
-          new Decimal(adjustedTokenMax),
-          bank.mintDecimals,
-        )
+        amount = new Decimal(tokenMax)
       }
       setInputAmount(amount.toFixed())
     },
-    [bank, adjustedTokenMax],
+    [bank, decimals, tokenMax],
   )
 
   const setMax = useCallback(() => {
     if (!bank) return
-    const max = floorToDecimal(adjustedTokenMax, bank.mintDecimals)
-    setInputAmount(max.toFixed())
+    setInputAmount(tokenMax.toFixed())
     setSizePercentage('100')
-  }, [bank, adjustedTokenMax])
+  }, [bank, tokenMax])
 
   const handleWithdraw = useCallback(async () => {
     const client = mangoStore.getState().client
@@ -118,7 +112,7 @@ function WithdrawForm({ onSuccess, token }: WithdrawFormProps) {
     setSubmitting(true)
 
     const withdrawAll =
-      floorToDecimal(adjustedTokenMax, bank.mintDecimals).eq(
+      floorToDecimal(tokenMax, bank.mintDecimals).eq(
         new Decimal(inputAmount),
       ) || sizePercentage === '100'
 
@@ -155,7 +149,7 @@ function WithdrawForm({ onSuccess, token }: WithdrawFormProps) {
         type: 'error',
       })
     }
-  }, [adjustedTokenMax, bank, inputAmount, sizePercentage])
+  }, [tokenMax, bank, inputAmount, sizePercentage])
 
   const handleSelectToken = useCallback((token: string) => {
     setSelectedToken(token)
@@ -217,10 +211,10 @@ function WithdrawForm({ onSuccess, token }: WithdrawFormProps) {
                 {bank ? (
                   <MaxAmountButton
                     className="mb-2"
-                    decimals={bank.mintDecimals}
+                    decimals={decimals}
                     label={t('max')}
                     onClick={setMax}
-                    value={adjustedTokenMax}
+                    value={tokenMax}
                   />
                 ) : null}
               </div>
@@ -239,7 +233,7 @@ function WithdrawForm({ onSuccess, token }: WithdrawFormProps) {
                   thousandSeparator=","
                   allowNegative={false}
                   isNumericString={true}
-                  decimalScale={bank?.mintDecimals || 6}
+                  decimalScale={bank ? bank.mintDecimals + 2 : 6}
                   className={ACCOUNT_ACTIONS_NUMBER_FORMAT_CLASSES}
                   placeholder="0.00"
                   value={inputAmount}
@@ -269,7 +263,12 @@ function WithdrawForm({ onSuccess, token }: WithdrawFormProps) {
                 />
                 <div className="flex justify-between">
                   <p>{t('withdraw-amount')}</p>
-                  <BankAmountWithValue amount={inputAmount} bank={bank} />
+                  <BankAmountWithValue
+                    amount={inputAmount}
+                    bank={bank}
+                    decimals={decimals}
+                    fixDecimals={false}
+                  />
                 </div>
               </div>
             ) : null}

--- a/components/account/ActionTokenItem.tsx
+++ b/components/account/ActionTokenItem.tsx
@@ -1,6 +1,7 @@
 import { Bank } from '@blockworks-foundation/mango-v4'
 import FormatNumericValue from '@components/shared/FormatNumericValue'
 import TokenLogo from '@components/shared/TokenLogo'
+import { floorToDecimal } from 'utils/numbers'
 
 const ActionTokenItem = ({
   bank,
@@ -18,6 +19,9 @@ const ActionTokenItem = ({
   showDepositRates?: boolean
 }) => {
   const { name } = bank
+  const decimals = floorToDecimal(customValue, bank.mintDecimals).toNumber()
+    ? bank.mintDecimals
+    : undefined
 
   return (
     <button
@@ -53,7 +57,7 @@ const ActionTokenItem = ({
         <p className="truncate font-mono text-th-fgd-1">
           <FormatNumericValue
             value={customValue}
-            decimals={bank.mintDecimals}
+            decimals={decimals}
             roundUp={roundUp}
           />
         </p>

--- a/components/shared/BankAmountWithValue.tsx
+++ b/components/shared/BankAmountWithValue.tsx
@@ -5,6 +5,7 @@ import FormatNumericValue from './FormatNumericValue'
 const BankAmountWithValue = ({
   amount = 0,
   bank,
+  decimals,
   fixDecimals = true,
   stacked,
   value,
@@ -12,6 +13,7 @@ const BankAmountWithValue = ({
 }: {
   amount: Decimal | number | string
   bank: Bank
+  decimals?: number
   fixDecimals?: boolean
   stacked?: boolean
   value?: number
@@ -22,12 +24,18 @@ const BankAmountWithValue = ({
       <>
         <FormatNumericValue
           value={amount}
-          decimals={amount && fixDecimals ? bank.mintDecimals : undefined}
+          decimals={
+            decimals
+              ? decimals
+              : amount && fixDecimals
+              ? bank.mintDecimals
+              : undefined
+          }
         />{' '}
         <span className={`text-th-fgd-4 ${stacked ? 'block' : ''}`}>
           <FormatNumericValue
             value={value ? value : Number(amount) * bank.uiPrice}
-            decimals={fixDecimals ? 2 : undefined}
+            decimals={decimals || fixDecimals ? 2 : undefined}
             isUsd={true}
             isPrivate={isPrivate}
           />

--- a/components/shared/MaxAmountButton.tsx
+++ b/components/shared/MaxAmountButton.tsx
@@ -11,7 +11,7 @@ const MaxAmountButton = ({
   value,
 }: {
   className?: string
-  decimals: number
+  decimals?: number
   disabled?: boolean
   label: string
   onClick: () => void

--- a/components/swap/useTokenMax.tsx
+++ b/components/swap/useTokenMax.tsx
@@ -13,10 +13,7 @@ export const getMaxWithdrawForBank = (
   mangoAccount: MangoAccount,
   allowBorrow = false,
 ): Decimal => {
-  const accountBalance = floorToDecimal(
-    mangoAccount.getTokenBalanceUi(bank),
-    bank.mintDecimals,
-  )
+  const accountBalance = new Decimal(mangoAccount.getTokenBalanceUi(bank))
   const vaultBalance = group.getTokenVaultBalanceByMintUi(bank.mint)
   const maxBorrow = floorToDecimal(
     mangoAccount.getMaxWithdrawWithBorrowForTokenUi(group, bank.mint),

--- a/hooks/useBanksWithBalances.ts
+++ b/hooks/useBanksWithBalances.ts
@@ -39,14 +39,7 @@ export default function useBanksWithBalances(
         }),
       ).map((b) => {
         const bank = b.value[0]
-        const rawBalance = mangoAccount
-          ? mangoAccount.getTokenBalanceUi(bank)
-          : 0
-        // For some reason if you don't use an abs value in floorToDecimal it returns incorrectly
-        const isBorrowMultiplier = rawBalance < 0 ? -1 : 1
-        const balance =
-          floorToDecimal(Math.abs(rawBalance), bank.mintDecimals).toNumber() *
-          isBorrowMultiplier
+        const balance = mangoAccount ? mangoAccount.getTokenBalanceUi(bank) : 0
 
         const maxBorrow = mangoAccount
           ? getMaxWithdrawForBank(group, bank, mangoAccount, true).toNumber()


### PR DESCRIPTION
Currently dust balances can be rounded down to 0. This displays dust balances so they can be withdrawn to close the token position on the account.