### PR TITLE
fix max errors for new listings with no price

### DIFF
--- a/components/NewListingBanner.tsx
+++ b/components/NewListingBanner.tsx
@@ -37,8 +37,10 @@ const NewListingBanner = () => {
     return market?.name
   }, [group, latestListing, serumMarkets])
 
-  return (!hasSeenNewListingBanner && latestListing) ||
-    (latestListing && hasSeenNewListingBanner !== latestListing?.name) ? (
+  const showForNewListing = latestListing && latestListing.uiPrice
+
+  return (!hasSeenNewListingBanner && showForNewListing) ||
+    (showForNewListing && hasSeenNewListingBanner !== latestListing?.name) ? (
     <div className="flex items-center justify-between bg-gradient-to-r from-yellow-400 via-orange-400 to-red-500 px-4 py-1">
       <div className="h-5 w-5" />
       <div className="mx-4 flex flex-wrap items-center justify-center font-bold text-black">

--- a/components/shared/TokenVaultWarnings.tsx
+++ b/components/shared/TokenVaultWarnings.tsx
@@ -1,5 +1,6 @@
 import { Bank } from '@blockworks-foundation/mango-v4'
 import {
+  getMaxBorrowForBank,
   getMaxWithdrawForBank,
   useTokenMax,
 } from '@components/swap/useTokenMax'
@@ -28,10 +29,7 @@ const TokenVaultWarnings = ({
       bank,
       mangoAccount,
     ).toNumber()
-    const maxBorrow = mangoAccount.getMaxWithdrawWithBorrowForTokenUi(
-      group,
-      bank.mint,
-    )
+    const maxBorrow = getMaxBorrowForBank(group, bank, mangoAccount).toNumber()
 
     return [maxWithdraw, maxBorrow]
   }, [bank, mangoAccount, group])

--- a/components/swap/useTokenMax.tsx
+++ b/components/swap/useTokenMax.tsx
@@ -7,6 +7,22 @@ import useMangoAccount from '../../hooks/useMangoAccount'
 import useMangoGroup from 'hooks/useMangoGroup'
 import { PublicKey } from '@solana/web3.js'
 
+export const getMaxBorrowForBank = (
+  group: Group,
+  bank: Bank,
+  mangoAccount: MangoAccount,
+) => {
+  try {
+    const maxBorrow = new Decimal(
+      mangoAccount.getMaxWithdrawWithBorrowForTokenUi(group, bank.mint),
+    )
+    return maxBorrow
+  } catch (e) {
+    console.log(`failed to get max borrow for ${bank.name}`, e)
+    return new Decimal(0)
+  }
+}
+
 export const getMaxWithdrawForBank = (
   group: Group,
   bank: Bank,
@@ -15,9 +31,7 @@ export const getMaxWithdrawForBank = (
 ): Decimal => {
   const accountBalance = new Decimal(mangoAccount.getTokenBalanceUi(bank))
   const vaultBalance = group.getTokenVaultBalanceByMintUi(bank.mint)
-  const maxBorrow = new Decimal(
-    mangoAccount.getMaxWithdrawWithBorrowForTokenUi(group, bank.mint),
-  )
+  const maxBorrow = getMaxBorrowForBank(group, bank, mangoAccount)
   const maxWithdraw = allowBorrow
     ? Decimal.min(vaultBalance, maxBorrow)
     : bank.initAssetWeight.toNumber() === 0

--- a/components/trade/MaxMarketTradeAmount.tsx
+++ b/components/trade/MaxMarketTradeAmount.tsx
@@ -29,7 +29,7 @@ const MaxMarketTradeAmount = ({
       decimals={decimals}
       label={t('max')}
       onClick={() => setMax(max)}
-      value={max}
+      value={isNaN(max.toNumber()) ? 0 : max}
     />
   )
 }

--- a/components/trade/MaxSizeButton.tsx
+++ b/components/trade/MaxSizeButton.tsx
@@ -108,7 +108,8 @@ const MaxSizeButton = ({
     const max = selectedMarket instanceof Serum3Market ? spotMax : perpMax || 0
     const tradePrice = tradeType === 'Market' ? oraclePrice : Number(price)
     if (side === 'buy') {
-      return max / tradePrice
+      const buyMax = max / tradePrice
+      return isNaN(buyMax) ? 0 : buyMax
     } else {
       return max
     }

--- a/store/mangoStore.ts
+++ b/store/mangoStore.ts
@@ -134,7 +134,6 @@ const initMangoClient = (
     prioritizationFee: opts.prioritizationFee,
     prependedGlobalAdditionalInstructions:
       opts.prependedGlobalAdditionalInstructions,
-    idsSource: 'api',
     postSendTxCallback: ({ txid }: { txid: string }) => {
       if (telemetry) {
         telemetry('postSendTx', {
@@ -602,9 +601,7 @@ const mangoStore = create<MangoStore>()(
             set((state) => {
               state.group = group
               state.groupLoaded = true
-              state.serumMarkets = serumMarkets.filter(
-                (mkt) => mkt.baseTokenIndex !== 777,
-              )
+              state.serumMarkets = serumMarkets
               state.perpMarkets = perpMarkets
               state.selectedMarket.current = selectedMarket
               if (!state.swap.inputBank && !state.swap.outputBank) {


### PR DESCRIPTION
– Switches to gPA (remove idsSource: 'api'
– Returns 0 when client function fails for max size calcs
– Only shows new listing banner if the new token has a price