### PR TITLE
Sets the default Jupiter Quote API to use one with higher rate limits

### DIFF
--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -129,7 +129,7 @@ export const JUPITER_API_DEVNET = 'https://api.jup.ag/api/tokens/devnet'
 
 export const JUPITER_PRICE_API_MAINNET = 'https://price.jup.ag/v4/' // V6 Does not yet support /price requests as of 16/10/2023
 
-export const JUPITER_V6_QUOTE_API_MAINNET = 'https://quote-api.jup.ag/v6'
+export const JUPITER_V6_QUOTE_API_MAINNET = process.env.NEXT_PUBLIC_JUPITER_V6_QUOTE_API_MAINNET || 'https://public.jupiterapi.com'
 
 export const NOTIFICATION_API = 'https://notifications-api.herokuapp.com/'
 


### PR DESCRIPTION
Since Jupiter V6 Swap API url is configured via an environment variable, we default the fallback to be [jupiterapi.com](https://www.jupiterapi.com/) in order to help with lower latency & rate limit issues.