### PR TITLE
Fix self delegated account settings

### DIFF
--- a/components/settings/AccountSettings.tsx
+++ b/components/settings/AccountSettings.tsx
@@ -57,7 +57,8 @@ const AccountSettings = () => {
   const { t } = useTranslation(['common', 'settings', 'trade'])
   const { mangoAccount, mangoAccountAddress } = useMangoAccount()
   const { group } = useMangoGroup()
-  const { isDelegatedAccount, isUnownedAccount } = useUnownedAccount()
+  const { isDelegatedAccount, isUnownedAccount, isOwnedAccount } =
+    useUnownedAccount()
   const { connected } = useWallet()
   const [showAccountSizeModal, setShowAccountSizeModal] = useState(false)
   const [showEditAccountModal, setShowEditAccountModal] = useState(false)
@@ -737,7 +738,7 @@ const AccountSettings = () => {
     <div className="rounded-lg border border-th-bkg-3 p-4 md:p-6">
       <p className="text-center">{t('settings:account-settings-unowned')}</p>
     </div>
-  ) : isDelegatedAccount ? (
+  ) : isDelegatedAccount && !isOwnedAccount ? (
     <div className="rounded-lg border border-th-bkg-3 p-4 md:p-6">
       <p className="text-center">{t('settings:account-settings-delegated')}</p>
     </div>

--- a/hooks/useUnownedAccount.ts
+++ b/hooks/useUnownedAccount.ts
@@ -5,6 +5,7 @@ import useMangoAccount from './useMangoAccount'
 const useUnownedAccount = (): {
   isUnownedAccount: boolean
   isDelegatedAccount: boolean
+  isOwnedAccount: boolean
 } => {
   const { connected, publicKey } = useWallet()
   const { mangoAccountAddress, mangoAccount } = useMangoAccount()
@@ -21,7 +22,14 @@ const useUnownedAccount = (): {
     return false
   }, [publicKey, mangoAccount])
 
-  return { isUnownedAccount, isDelegatedAccount }
+  const isOwnedAccount: boolean = useMemo(() => {
+    if (publicKey && mangoAccount) {
+      return mangoAccount?.owner.equals(publicKey)
+    }
+    return false
+  }, [publicKey, mangoAccount])
+
+  return { isUnownedAccount, isDelegatedAccount, isOwnedAccount }
 }
 
 export default useUnownedAccount


### PR DESCRIPTION
Users can't access account settings in the rare case the account is delegated to their own wallet